### PR TITLE
feat(django): 検索機能の実装

### DIFF
--- a/puzlle_maker/puzzle/admin.py
+++ b/puzlle_maker/puzzle/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
-
+from .models import Puzzle
 # Register your models here.
+
+
+admin.site.register(Puzzle)

--- a/puzlle_maker/puzzle/helper.py
+++ b/puzlle_maker/puzzle/helper.py
@@ -1,4 +1,4 @@
-def create_index(puzzles_nums):
-    index = puzzles_nums / 30 if (puzzles_nums % 30) == 0\
-        else puzzles_nums / 30 + 1
+def create_index(puzzles_nums, margin):
+    index = puzzles_nums / margin if (puzzles_nums % margin) == 0\
+        else (puzzles_nums / margin) + 1
     return [i+1 for i in range(int(index))]

--- a/puzlle_maker/puzzle/helper.py
+++ b/puzlle_maker/puzzle/helper.py
@@ -1,0 +1,4 @@
+def create_index(puzzles_nums):
+    index = puzzles_nums / 30 if (puzzles_nums % 30) == 0\
+        else puzzles_nums / 30 + 1
+    return [i+1 for i in range(int(index))]

--- a/puzlle_maker/puzzle/helper.py
+++ b/puzlle_maker/puzzle/helper.py
@@ -1,3 +1,8 @@
+def more_than_specified_number(amount, specified_number=0):
+    return specified_number \
+        if specified_number <= amount else amount
+
+
 def create_index(puzzles_nums, margin):
     index = 1
     if puzzles_nums / margin == 0:

--- a/puzlle_maker/puzzle/helper.py
+++ b/puzlle_maker/puzzle/helper.py
@@ -1,4 +1,10 @@
 def create_index(puzzles_nums, margin):
-    index = puzzles_nums / margin if (puzzles_nums % margin) == 0\
-        else (puzzles_nums / margin) + 1
+    index = 1
+    if puzzles_nums / margin == 0:
+        index = 1
+    elif puzzles_nums % margin == 0:
+        index = puzzles_nums / margin
+    else:
+        index = (puzzles_nums / margin) + 1
+
     return [i+1 for i in range(int(index))]

--- a/puzlle_maker/puzzle/templates/search_result.html
+++ b/puzlle_maker/puzzle/templates/search_result.html
@@ -18,5 +18,11 @@
 {% endif %}
 {% if request.path == '/'%}
 <script src="{% static 'js/script.js' %}"></script>
+{% else %}
+<ul>
+  {% for i in count %}
+  <li>{{i}}</li>
+  {% endfor %}
+</ul>
 {% endif %}
 {% endblock %}

--- a/puzlle_maker/puzzle/templates/search_result.html
+++ b/puzlle_maker/puzzle/templates/search_result.html
@@ -19,9 +19,9 @@
 {% if request.path == '/'%}
 <script src="{% static 'js/script.js' %}"></script>
 {% else %}
-<ul>
+<ul class="link-list">
   {% for i in count %}
-  <li>{{i}}</li>
+  <li><a href="{% url 'search puzzle data' %}?search_words={{search_words}}&id={{i}}">{{i}}</a></li>
   {% endfor %}
 </ul>
 {% endif %}

--- a/puzlle_maker/puzzle/templates/search_result.html
+++ b/puzlle_maker/puzzle/templates/search_result.html
@@ -16,5 +16,7 @@
   <h2>パズルが投稿されていません</h2>
 </div>
 {% endif %}
+{% if request.path == '/'%}
 <script src="{% static 'js/script.js' %}"></script>
+{% endif %}
 {% endblock %}

--- a/puzlle_maker/puzzle/tests/test_helper_view.py
+++ b/puzlle_maker/puzzle/tests/test_helper_view.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+from puzzle.helper import create_index
+
+
+class HelperFunctionTest(TestCase):
+    def test_create_index_mod_zero(self):
+        self.assertEquals(create_index(30), [i+1 for i in range(1)])
+
+    def test_create_index(self):
+        self.assertEquals(create_index(31), [i+1 for i in range(2)])

--- a/puzlle_maker/puzzle/tests/test_helper_view.py
+++ b/puzlle_maker/puzzle/tests/test_helper_view.py
@@ -4,7 +4,7 @@ from puzzle.helper import create_index
 
 class HelperFunctionTest(TestCase):
     def test_create_index_mod_zero(self):
-        self.assertEquals(create_index(30), [i+1 for i in range(1)])
+        self.assertEquals(create_index(30, 30), [i+1 for i in range(1)])
 
     def test_create_index(self):
-        self.assertEquals(create_index(31), [i+1 for i in range(2)])
+        self.assertEquals(create_index(31, 30), [i+1 for i in range(2)])

--- a/puzlle_maker/puzzle/tests/test_integration.py
+++ b/puzlle_maker/puzzle/tests/test_integration.py
@@ -80,7 +80,7 @@ class IntegrationTest(LiveServerTestCase):
         submit_button.click()
 
         self.assertEquals(self.selenium.current_url, '%s%s' % (
-            self.live_server_url, '/puzzles/?search_words=test1'))
+            self.live_server_url, '/puzzles/?search_words=test1&id=1'))
 
         search_result = self.selenium.find_elements_by_class_name('puzzle')
         self.assertEquals(len(search_result), 2)
@@ -90,3 +90,7 @@ class IntegrationTest(LiveServerTestCase):
         self.selenium.page_source
         search_result = self.selenium.find_elements_by_class_name('puzzle')
         self.assertEquals(len(search_result), 2)
+
+        search_result_index = self.selenium.find_element_by_class_name(
+            'link-list')
+        self.assertIsNotNone(search_result_index)

--- a/puzlle_maker/puzzle/tests/test_integration.py
+++ b/puzlle_maker/puzzle/tests/test_integration.py
@@ -112,6 +112,8 @@ class IntegrationTest(LiveServerTestCase):
         search_result_links = search_result_index.find_elements_by_tag_name(
             "li")
         self.assertEquals(len(search_result_links), 2)
+        self.assertEquals(
+            len(self.selenium.find_elements_by_class_name('puzzle')), 30)
 
         second_result_page_link = \
             self.selenium.find_element_by_link_text('2')
@@ -122,3 +124,5 @@ class IntegrationTest(LiveServerTestCase):
                               self.live_server_url,
                               '/puzzles/?search_words=test&id=2'
                           ))
+        self.assertEquals(
+            len(self.selenium.find_elements_by_class_name('puzzle')), 10)

--- a/puzlle_maker/puzzle/tests/test_integration.py
+++ b/puzlle_maker/puzzle/tests/test_integration.py
@@ -68,3 +68,19 @@ class IntegrationTest(LiveServerTestCase):
         self.selenium.page_source
         loaded_puzzle = self.selenium.find_elements_by_class_name('puzzle')
         self.assertEquals(len(loaded_puzzle), 40)
+
+    def test_enter_in_the_search_field_and_behave_after_the_search(self):
+        make_Puzzles(11)
+        self.selenium.get('%s%s' % (self.live_server_url, '/'))
+
+        search_field = self.selenium.find_element_by_tag_name('input')
+        search_field.send_keys('test1')
+        submit_button = self.selenium.find_element_by_class_name(
+            'puzzle-search-btn')
+        submit_button.click()
+
+        self.assertEquals(self.selenium.current_url, '%s%s' % (
+            self.live_server_url, '/puzzles/?search_words=test1'))
+
+        search_result = self.selenium.find_elements_by_class_name('puzzle')
+        self.assertEquals(len(search_result), 2)

--- a/puzlle_maker/puzzle/tests/test_integration.py
+++ b/puzlle_maker/puzzle/tests/test_integration.py
@@ -96,3 +96,29 @@ class IntegrationTest(LiveServerTestCase):
         self.assertIsNotNone(search_result_index)
         self.assertEquals(
             len(search_result_index.find_elements_by_tag_name("li")), 1)
+
+    def test_can_you_access_the_link_properly(self):
+        make_Puzzles(40)
+        self.selenium.get('%s%s' % (self.live_server_url, '/'))
+
+        search_field = self.selenium.find_element_by_tag_name('input')
+        search_field.send_keys('test')
+        submit_button = self.selenium.find_element_by_class_name(
+            'puzzle-search-btn')
+        submit_button.click()
+
+        search_result_index = self.selenium.find_element_by_class_name(
+            'link-list')
+        search_result_links = search_result_index.find_elements_by_tag_name(
+            "li")
+        self.assertEquals(len(search_result_links), 2)
+
+        second_result_page_link = \
+            self.selenium.find_element_by_link_text('2')
+        second_result_page_link.click()
+
+        self.assertEquals(self.selenium.current_url,
+                          '%s%s' % (
+                              self.live_server_url,
+                              '/puzzles/?search_words=test&id=2'
+                          ))

--- a/puzlle_maker/puzzle/tests/test_integration.py
+++ b/puzlle_maker/puzzle/tests/test_integration.py
@@ -94,3 +94,5 @@ class IntegrationTest(LiveServerTestCase):
         search_result_index = self.selenium.find_element_by_class_name(
             'link-list')
         self.assertIsNotNone(search_result_index)
+        self.assertEquals(
+            len(search_result_index.find_elements_by_tag_name("li")), 1)

--- a/puzlle_maker/puzzle/tests/test_integration.py
+++ b/puzlle_maker/puzzle/tests/test_integration.py
@@ -84,3 +84,9 @@ class IntegrationTest(LiveServerTestCase):
 
         search_result = self.selenium.find_elements_by_class_name('puzzle')
         self.assertEquals(len(search_result), 2)
+
+        self.selenium.execute_script(
+            "window.scrollTo(0, document.body.scrollHeight)")
+        self.selenium.page_source
+        search_result = self.selenium.find_elements_by_class_name('puzzle')
+        self.assertEquals(len(search_result), 2)

--- a/puzlle_maker/puzzle/tests/test_urls.py
+++ b/puzlle_maker/puzzle/tests/test_urls.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.urls import reverse, resolve
-from puzzle.views import index, get_puzzle_data
+from puzzle.views import index, get_puzzle_data, search_puzzle_data
 
 
 class UrlsTest(TestCase):
@@ -11,3 +11,7 @@ class UrlsTest(TestCase):
     def test_get_additional_puzzle_url(self):
         url = reverse('get puzzle data', kwargs={'id': 1})
         self.assertEqual(resolve(url).func, get_puzzle_data)
+
+    def test_search_puzzle_data_url(self):
+        url = reverse('search puzzle data', kwargs={'search_words': 'test'})
+        self.assertEquals(resolve(url).func, search_puzzle_data)

--- a/puzlle_maker/puzzle/tests/test_urls.py
+++ b/puzlle_maker/puzzle/tests/test_urls.py
@@ -13,5 +13,5 @@ class UrlsTest(TestCase):
         self.assertEqual(resolve(url).func, get_puzzle_data)
 
     def test_search_puzzle_data_url(self):
-        url = reverse('search puzzle data', kwargs={'search_words': 'test'})
+        url = reverse('search puzzle data')
         self.assertEquals(resolve(url).func, search_puzzle_data)

--- a/puzlle_maker/puzzle/tests/test_views.py
+++ b/puzlle_maker/puzzle/tests/test_views.py
@@ -53,3 +53,8 @@ class ViewsTest(TestCase):
                               user_id="abdg3fh")
         response = self.client.get("/puzzles/?search_words=test1 cat")
         self.assertEquals(len(response.context['puzzle']), 12)
+
+    def test_search_with_blanks(self):
+        response = self.client.get('/puzzles/')
+        self.assertEquals(response.status_code, 302)
+        self.assertEquals(response.url, '/')

--- a/puzlle_maker/puzzle/tests/test_views.py
+++ b/puzlle_maker/puzzle/tests/test_views.py
@@ -37,3 +37,9 @@ class ViewsTest(TestCase):
         response = self.client.get(url)
         additional_puzzles = response.json()
         self.assertEquals(len(additional_puzzles), 2)
+
+    def test_search_for_words_equals_title_puzzle_data(self):
+        response = self.client.get('/puzzles/?search_words=test')
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.context['puzzle'],
+                          list(Puzzle.objects.all().values())[:62])

--- a/puzlle_maker/puzzle/tests/test_views.py
+++ b/puzlle_maker/puzzle/tests/test_views.py
@@ -58,3 +58,7 @@ class ViewsTest(TestCase):
         response = self.client.get('/puzzles/')
         self.assertEquals(response.status_code, 302)
         self.assertEquals(response.url, '/')
+
+    def test_no_work_that_matches_the_search_results(self):
+        response = self.client.get('/puzzles/?search_words=aaaaaaaa')
+        self.assertIn("パズルが投稿されていません", response.content.decode())

--- a/puzlle_maker/puzzle/tests/test_views.py
+++ b/puzlle_maker/puzzle/tests/test_views.py
@@ -42,7 +42,17 @@ class ViewsTest(TestCase):
         response = self.client.get('/puzzles/?search_words=test')
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.context['puzzle'],
-                          list(Puzzle.objects.all().values())[:62])
+                          list(Puzzle.objects.all().values())[:30])
+
+        response = self.client.get('/puzzles/?search_words=test&id=2')
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.context['puzzle'],
+                          list(Puzzle.objects.all().values())[30:60])
+
+        response = self.client.get('/puzzles/?search_words=test&id=3')
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.context['puzzle'],
+                          list(Puzzle.objects.all().values())[60:62])
 
     def test_search_by_multiple_words(self):
         Puzzle.objects.create(title="cat",
@@ -60,5 +70,5 @@ class ViewsTest(TestCase):
         self.assertEquals(response.url, '/')
 
     def test_no_work_that_matches_the_search_results(self):
-        response = self.client.get('/puzzles/?search_words=aaaaaaaa')
+        response = self.client.get('/puzzles/?search_words=aaaaaaaa&id=1')
         self.assertIn("パズルが投稿されていません", response.content.decode())

--- a/puzlle_maker/puzzle/tests/test_views.py
+++ b/puzlle_maker/puzzle/tests/test_views.py
@@ -38,8 +38,18 @@ class ViewsTest(TestCase):
         additional_puzzles = response.json()
         self.assertEquals(len(additional_puzzles), 2)
 
-    def test_search_for_words_equals_title_puzzle_data(self):
+    def test_search_for_word_equals_title_puzzle_data(self):
         response = self.client.get('/puzzles/?search_words=test')
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.context['puzzle'],
                           list(Puzzle.objects.all().values())[:62])
+
+    def test_search_by_multiple_words(self):
+        Puzzle.objects.create(title="cat",
+                              size=2,
+                              created_at=timezone.now(),
+                              update_at=timezone.now(),
+                              picture_url="test.png",
+                              user_id="abdg3fh")
+        response = self.client.get("/puzzles/?search_words=test1 cat")
+        self.assertEquals(len(response.context['puzzle']), 12)

--- a/puzlle_maker/puzzle/urls.py
+++ b/puzlle_maker/puzzle/urls.py
@@ -3,5 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
-    path('puzzles/<int:id>', views.get_puzzle_data, name='get puzzle data')
+    path('puzzles/<int:id>', views.get_puzzle_data, name='get puzzle data'),
+    path('puzzles/<str:search_words>',
+         views.search_puzzle_data, name='search puzzle data')
 ]

--- a/puzlle_maker/puzzle/urls.py
+++ b/puzlle_maker/puzzle/urls.py
@@ -3,7 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('puzzles/',
+         views.search_puzzle_data, name='search puzzle data'),
     path('puzzles/<int:id>', views.get_puzzle_data, name='get puzzle data'),
-    path('puzzles/<str:search_words>',
-         views.search_puzzle_data, name='search puzzle data')
 ]

--- a/puzlle_maker/puzzle/views.py
+++ b/puzlle_maker/puzzle/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from django.db.models import Q
 from puzzle.models import Puzzle
+from puzzle.helper import create_index
 import json
 # Create your views here.
 
@@ -31,8 +32,10 @@ def search_puzzle_data(request):
         for q in q_objects:
             query |= q
 
-        puzzle_data = Puzzle.objects.filter(query)
-        puzzle_data = {'puzzle': list(puzzle_data.values())}
+        puzzle_model = Puzzle.objects.filter(query)
+
+        puzzle_data = {'puzzle': list(
+            puzzle_model.values()), 'count': create_index(len(puzzle_model))}
         return render(request, './search_result.html', puzzle_data)
     else:
         return redirect('index')

--- a/puzlle_maker/puzzle/views.py
+++ b/puzlle_maker/puzzle/views.py
@@ -20,12 +20,10 @@ def get_puzzle_data(request, id):
 
 
 def search_puzzle_data(request, search_words):
-    puzzle_data = Puzzle.objects.all()
     if search_words:
         search_words = search_words.split()
         print(search_words)
-        for word in search_words:
-            puzzle_data = puzzle_data.filter(title__icontains=word)
+        puzzle_data = Puzzle.objects.filter(title__in=search_words)
 
         puzzle_data = list(puzzle_data.values())
         return HttpResponse(json.dumps(puzzle_data, ensure_ascii=False,

--- a/puzlle_maker/puzzle/views.py
+++ b/puzlle_maker/puzzle/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from django.db.models import Q
 from puzzle.models import Puzzle
-from puzzle.helper import create_index
+from puzzle.helper import create_index, more_than_specified_number
 import json
 # Create your views here.
 
@@ -15,7 +15,7 @@ def index(request):
 
 def get_puzzle_data(request, id):
     count = Puzzle.objects.all().count()
-    end = (id + 1) * 30 if (id + 1) * 30 <= count else count
+    end = more_than_specified_number(count, (id + 1) * 30)
     data = list(Puzzle.objects.filter().values())[id * 30:end]
     return HttpResponse(json.dumps(data, ensure_ascii=False, default=str),
                         content_type="application/json")
@@ -23,7 +23,7 @@ def get_puzzle_data(request, id):
 
 def search_puzzle_data(request):
     search_words = request.GET.get('search_words')
-    id = int(request.GET.get('id'))
+    id = int(request.GET.get('id')) if request.GET.get('id') else 1
 
     if search_words:
         search_words_list = search_words.split()
@@ -34,13 +34,16 @@ def search_puzzle_data(request):
             query |= q
 
         puzzle_model = Puzzle.objects.filter(query)
+        count = create_index(puzzle_model.count(), 30)
+        next_or_end_works_index = more_than_specified_number(
+            puzzle_model.count(), id*30)
 
         puzzle_data = {
-            'puzzle': list(puzzle_model[(id - 1) * 30:id * 30].values()),
+            'puzzle':
+            list(puzzle_model[(id - 1) * 30:next_or_end_works_index].values()),
             'search_words': search_words,
-            'count': create_index(len(puzzle_model), 2)
+            'count': count
         }
-
         return render(request, './search_result.html', puzzle_data)
     else:
         return redirect('index')

--- a/puzlle_maker/puzzle/views.py
+++ b/puzlle_maker/puzzle/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.http import HttpResponse
+from django.db.models import Q
 from puzzle.models import Puzzle
 import json
 # Create your views here.
@@ -24,9 +25,13 @@ def search_puzzle_data(request):
 
     if search_words:
         search_words = search_words.split()
-        print(search_words)
-        puzzle_data = Puzzle.objects.filter(title__in=search_words)
 
+        q_objects = [Q(title__icontains=s) for s in search_words]
+        query = q_objects.pop()
+        for q in q_objects:
+            query |= q
+
+        puzzle_data = Puzzle.objects.filter(query)
         puzzle_data = {'puzzle': list(puzzle_data.values())}
         return render(request, './search_result.html', puzzle_data)
     else:

--- a/puzlle_maker/puzzle/views.py
+++ b/puzlle_maker/puzzle/views.py
@@ -27,9 +27,7 @@ def search_puzzle_data(request):
         print(search_words)
         puzzle_data = Puzzle.objects.filter(title__in=search_words)
 
-        puzzle_data = list(puzzle_data.values())
-        return HttpResponse(json.dumps(puzzle_data, ensure_ascii=False,
-                                       default=str),
-                            content_type='applicaion/json')
+        puzzle_data = {'puzzle': list(puzzle_data.values())}
+        return render(request, './search_result.html', puzzle_data)
     else:
         return redirect('index')

--- a/puzlle_maker/puzzle/views.py
+++ b/puzlle_maker/puzzle/views.py
@@ -23,19 +23,24 @@ def get_puzzle_data(request, id):
 
 def search_puzzle_data(request):
     search_words = request.GET.get('search_words')
+    id = int(request.GET.get('id'))
 
     if search_words:
-        search_words = search_words.split()
+        search_words_list = search_words.split()
 
-        q_objects = [Q(title__icontains=s) for s in search_words]
+        q_objects = [Q(title__icontains=s) for s in search_words_list]
         query = q_objects.pop()
         for q in q_objects:
             query |= q
 
         puzzle_model = Puzzle.objects.filter(query)
 
-        puzzle_data = {'puzzle': list(
-            puzzle_model.values()), 'count': create_index(len(puzzle_model))}
+        puzzle_data = {
+            'puzzle': list(puzzle_model[(id - 1) * 30:id * 30].values()),
+            'search_words': search_words,
+            'count': create_index(len(puzzle_model), 2)
+        }
+
         return render(request, './search_result.html', puzzle_data)
     else:
         return redirect('index')

--- a/puzlle_maker/puzzle/views.py
+++ b/puzlle_maker/puzzle/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from puzzle.models import Puzzle
 import json
@@ -17,3 +17,19 @@ def get_puzzle_data(request, id):
     data = list(Puzzle.objects.filter().values())[id * 30:end]
     return HttpResponse(json.dumps(data, ensure_ascii=False, default=str),
                         content_type="application/json")
+
+
+def search_puzzle_data(request, search_words):
+    puzzle_data = Puzzle.objects.all()
+    if search_words:
+        search_words = search_words.split()
+        print(search_words)
+        for word in search_words:
+            puzzle_data = puzzle_data.filter(title__icontains=word)
+
+        puzzle_data = list(puzzle_data.values())
+        return HttpResponse(json.dumps(puzzle_data, ensure_ascii=False,
+                                       default=str),
+                            content_type='applicaion/json')
+    else:
+        return redirect('index')

--- a/puzlle_maker/puzzle/views.py
+++ b/puzlle_maker/puzzle/views.py
@@ -19,7 +19,9 @@ def get_puzzle_data(request, id):
                         content_type="application/json")
 
 
-def search_puzzle_data(request, search_words):
+def search_puzzle_data(request):
+    search_words = request.GET.get('search_words')
+
     if search_words:
         search_words = search_words.split()
         print(search_words)

--- a/puzlle_maker/static/dev/css/body.css
+++ b/puzlle_maker/static/dev/css/body.css
@@ -44,6 +44,7 @@ aside nav ul li:hover {
   display: flex;
   flex-wrap: wrap;
   padding-bottom: 100px;
+  min-height: 800px;
 }
 
 .puzzle-container .puzzle {
@@ -62,4 +63,25 @@ aside nav ul li:hover {
 
 .puzzle-container .puzzle .user-icon {
   margin-top: 20px;
+}
+
+.link-list {
+  list-style-type: none;
+  font-size: 18px;
+  text-align: center;
+}
+
+.link-list li {
+  display: inline;
+  margin: 10px;
+  font-size: 24px;
+}
+
+.link-list li a {
+  text-decoration: none;
+  color: black;
+}
+
+.link-list li a:hover {
+  color: orange;
 }

--- a/puzlle_maker/static/dev/scss/body.scss
+++ b/puzlle_maker/static/dev/scss/body.scss
@@ -34,6 +34,7 @@ aside {
 .container {
   margin-left: 300px;
   height: 100%;
+
   .no-puzzle-data-msg {
     text-align: center;
   }
@@ -43,6 +44,7 @@ aside {
   display: flex;
   flex-wrap: wrap;
   padding-bottom: 100px;
+  min-height: 800px;
 
   .puzzle {
     width: 300px;
@@ -58,6 +60,25 @@ aside {
     }
     .user-icon {
       margin-top: 20px;
+    }
+  }
+}
+
+.link-list {
+  list-style-type: none;
+  font-size: 18px;
+  text-align: center;
+
+  li {
+    display: inline;
+    margin: 10px;
+    font-size: 24px;
+    a {
+      text-decoration: none;
+      color: black;
+      &:hover {
+        color: orange;
+      }
     }
   }
 }

--- a/puzlle_maker/templates/base.html
+++ b/puzlle_maker/templates/base.html
@@ -18,6 +18,7 @@
       <div class="puzzle-search">
         <form method="GET" action="{% url 'search puzzle data' %}">
           <input type="text" name='search_words' class="puzzle-search-bar" />
+          <input type="hidden" name="id" value=1>
           <button type="submit" class="puzzle-search-btn"><i class="fas fa-search"></i></button>
         </form>
       </div>

--- a/puzlle_maker/templates/base.html
+++ b/puzlle_maker/templates/base.html
@@ -16,8 +16,10 @@
     <header>
       <h1 class="logo"><a href="{% url 'index' %}">PuzzleMaker</a></h1>
       <div class="puzzle-search">
-        <input type="text" class="puzzle-search-bar" />
-        <button class="puzzle-search-btn"><i class="fas fa-search"></i></button>
+        <form method="GET" action="{% url 'search puzzle data' %}">
+          <input type="text" name='search_words' class="puzzle-search-bar" />
+          <button type="submit" class="puzzle-search-btn"><i class="fas fa-search"></i></button>
+        </form>
       </div>
     </header>
     {% block sidebar %}{% endblock %}


### PR DESCRIPTION
## 概要
トップ画面の検索用のインプットフィールドに入力された単語に対応する  
作品名の作品を抽出、表示する

|実装後|
|---|
|![Peek 2021-12-06 21-56](https://user-images.githubusercontent.com/38244340/144850162-f852bebf-9721-456e-8dd9-4eaaf190dc41.gif) |

## 要件
- [x] inputフィールドに入力された単語を使ってPuzzleモデルを検索できる
- [x] inputフィールドに入力された文字列を空白でsplitする
- [x] 空白で検索した場合、トップ画面に遷移する
- [x] 複数の単語での検索に対応できる
- [x] 検索結果の総数 / 30でページ数を分割できる  